### PR TITLE
Fix audio recordings

### DIFF
--- a/grabber.rb
+++ b/grabber.rb
@@ -35,7 +35,8 @@ class Video
   end
 
   def filename
-    "#{created_at}_#{lecture.course.gsub(' ', '-')}_#{lecture.code}_#{id}.mp4"
+    extension = "#{url.match(/\w+$/)}"
+    "#{created_at}_#{lecture.course.gsub(' ', '-')}_#{lecture.code}_#{id}.#{extension}"
   end
 end
 

--- a/grabber.rb
+++ b/grabber.rb
@@ -115,8 +115,19 @@ class Lecture
     end.body).to_h
   end
 
+  def episode_audios(id)
+    JSON.parse(Faraday.get('https://video.ethz.ch/.episode-audio.json') do |req|
+      req.params['recordId'] = id
+      req.headers['cookie'] = cookie if protected?
+    end.body).to_h
+  end
+
   def best_video_url(id)
-    episode_videos(id)['streams'][0]['sources']['mp4'].max { |a, b| a['res']['w'].to_i - b['res']['w'].to_i }['src']
+    unless episode_videos(id)['streams'].length() == 0
+      episode_videos(id)['streams'][0]['sources']['mp4'].max { |a, b| a['res']['w'].to_i - b['res']['w'].to_i }['src']
+    else
+      episode_audios(id)['sources'][0]['src']
+    end
   end
 
   def protected?


### PR DESCRIPTION
Fix the issue where the script would crash when it encountered an audio recording of a lecture. Now the audio recordings get downloaded properly in the same way as the videos, with the same filename scheme. It always downloads the first available format, which in all tested cases was M4A.